### PR TITLE
fix: upgrade PostgreSQL to v14 for Django 5.2.4 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           - 6379:6379
         options: --health-cmd="redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3
       postgres:
-        image: postgres:13
+        image: postgres:14
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
- Update CI/CD PostgreSQL service from v13 to v14 (required by Django 5.2.4)
- Add dj-database-url dependency for DATABASE_URL parsing in CI/CD
- Ensure full compatibility across all environments (local, Docker, CI/CD)